### PR TITLE
Fix missing heic-convert dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repository provides a small Node.js script to convert all `.heic` files in 
    ```bash
    npm install
    ```
+
+   이 단계에서 변환에 필요한 `heic-convert` 모듈이 함께 설치됩니다.
 2. 변환하고자 하는 폴더 경로를 지정하여 스크립트를 실행합니다.
    ```bash
    node convert.js /path/to/heic-folder

--- a/convert.js
+++ b/convert.js
@@ -1,6 +1,12 @@
 const fs = require('fs').promises;
 const path = require('path');
-const heicConvert = require('heic-convert');
+let heicConvert;
+try {
+  heicConvert = require('heic-convert');
+} catch (err) {
+  console.error('Missing dependency: heic-convert. Please run "npm install" first.');
+  process.exit(1);
+}
 
 async function convertDirectory(dir) {
   const entries = await fs.readdir(dir);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "convert": "node convert.js"
   },
+  "dependencies": {
+    "heic-convert": "^1.0.0"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
## Summary
- add `heic-convert` as a project dependency
- note that running `npm install` installs the module
- show a helpful message when `heic-convert` is not installed

## Testing
- `node convert.js ./image/`