### PR TITLE
Handle HEIC extension case-insensitively

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # HEIC to JPEG Converter
 
 This repository provides a small Node.js script to convert all `.heic` files in a given folder to JPEG images.
+The extension check is case-insensitive, so files like `example.HEIC` are also converted.
 
 ## 사용법 (Usage)
 

--- a/convert.js
+++ b/convert.js
@@ -13,10 +13,11 @@ async function convertDirectory(dir) {
   const outputDir = path.join(dir, 'convert');
   await fs.mkdir(outputDir, { recursive: true });
   for (const entry of entries) {
-    const ext = path.extname(entry).toLowerCase();
+    const parsed = path.parse(entry);
+    const ext = parsed.ext.toLowerCase();
     if (ext === '.heic') {
       const inputPath = path.join(dir, entry);
-      const outputPath = path.join(outputDir, path.basename(entry, ext) + '.jpg');
+      const outputPath = path.join(outputDir, parsed.name + '.jpg');
       const inputBuffer = await fs.readFile(inputPath);
       const outputBuffer = await heicConvert({
         buffer: inputBuffer,


### PR DESCRIPTION
## Summary
- fix extension parsing so `.HEIC` also matches
- mention case-insensitive check in README

## Testing
- `npm test` *(fails: Missing script: "test")*